### PR TITLE
feat: add FastifyPluginAsyncJsonSchemaToTs and FastifyPluginCallbackJsonSchemaToTs plugin types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ A Type Provider for json-schema-to-ts
 > When using plugin types, withTypeProvider is not required in order to register the plugin
 
 ```ts
-const plugin: FastifyPluginAsyncJStT = async function (fastify, _opts) {
+const plugin: FastifyPluginAsyncJsonSchemaToTs = async function (
+  fastify,
+  _opts
+) {
   fastify.get(
     "/",
     {

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # fastify-type-provider-json-schema-to-ts
+
 A Type Provider for json-schema-to-ts
+
+## Plugin definition
+
+> **Note**
+> When using plugin types, withTypeProvider is not required in order to register the plugin
+
+```ts
+const plugin: FastifyPluginAsyncJStT = async function (fastify, _opts) {
+  fastify.get(
+    "/",
+    {
+      schema: {
+        body: {
+          type: "object",
+          properties: {
+            x: { type: "string" },
+            y: { type: "number" },
+            z: { type: "boolean" },
+          },
+          required: ["x", "y", "z"],
+        } as const,
+      },
+    },
+    (req) => {
+      /// The `x`, `y`, and `z` types are automatically inferred
+      const { x, y, z } = req.body;
+    }
+  );
+};
+```

--- a/index.ts
+++ b/index.ts
@@ -18,14 +18,14 @@ export interface JsonSchemaToTsProvider extends FastifyTypeProvider {
  *
  * @example
  * ```typescript
- * import { FastifyPluginCallbackJStT } from "@fastify/type-provider-json-schema-to-ts"
+ * import { FastifyPluginCallbackJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts"
  *
- * const plugin: FastifyPluginCallbackJStT = (fastify, options, done) => {
+ * const plugin: FastifyPluginCallbackJsonSchemaToTs = (fastify, options, done) => {
  *   done()
  * }
  * ```
  */
-export type FastifyPluginCallbackJStT<
+export type FastifyPluginCallbackJsonSchemaToTs<
   Options extends FastifyPluginOptions = Record<never, never>,
   Server extends RawServerBase = RawServerDefault
 > = FastifyPluginCallback<Options, Server, JsonSchemaToTsProvider>;
@@ -41,7 +41,7 @@ export type FastifyPluginCallbackJStT<
  * }
  * ```
  */
-export type FastifyPluginAsyncJStT<
+export type FastifyPluginAsyncJsonSchemaToTs<
   Options extends FastifyPluginOptions = Record<never, never>,
   Server extends RawServerBase = RawServerDefault
 > = FastifyPluginAsync<Options, Server, JsonSchemaToTsProvider>;

--- a/index.ts
+++ b/index.ts
@@ -35,9 +35,9 @@ export type FastifyPluginCallbackJsonSchemaToTs<
  *
  * @example
  * ```typescript
- * import { FastifyPluginAsyncJStT } fromg "@fastify/type-provider-json-schema-to-ts"
+ * import { FastifyPluginAsyncJsonSchemaToTs } fromg "@fastify/type-provider-json-schema-to-ts"
  *
- * const plugin: FastifyPluginAsyncJStT = async (fastify, options) => {
+ * const plugin: FastifyPluginAsyncJsonSchemaToTs = async (fastify, options) => {
  * }
  * ```
  */

--- a/index.ts
+++ b/index.ts
@@ -14,13 +14,13 @@ export interface JsonSchemaToTsProvider extends FastifyTypeProvider {
 }
 
 /**
- * FastifyPluginCallback with Typebox automatic type inference
+ * FastifyPluginCallback with JSON Schema to Typescript automatic type inference
  *
  * @example
  * ```typescript
- * import { FastifyPluginCallbackTypebox } fromg "@fastify/type-provider-typebox"
+ * import { FastifyPluginCallbackJStT } from "@fastify/type-provider-json-schema-to-ts"
  *
- * const plugin: FastifyPluginCallbackTypebox = (fastify, options, done) => {
+ * const plugin: FastifyPluginCallbackJStT = (fastify, options, done) => {
  *   done()
  * }
  * ```
@@ -31,13 +31,13 @@ export type FastifyPluginCallbackJStT<
 > = FastifyPluginCallback<Options, Server, JsonSchemaToTsProvider>;
 
 /**
- * FastifyPluginAsync with Typebox automatic type inference
+ * FastifyPluginAsync with JSON Schema to Typescript automatic type inference
  *
  * @example
  * ```typescript
- * import { FastifyPluginAsyncTypebox } fromg "@fastify/type-provider-typebox"
+ * import { FastifyPluginAsyncJStT } fromg "@fastify/type-provider-json-schema-to-ts"
  *
- * const plugin: FastifyPluginAsyncTypebox = async (fastify, options) => {
+ * const plugin: FastifyPluginAsyncJStT = async (fastify, options) => {
  * }
  * ```
  */

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,47 @@
-import { FastifyTypeProvider } from 'fastify'
+import {
+  FastifyTypeProvider,
+  FastifyPluginOptions,
+  RawServerBase,
+  RawServerDefault,
+  FastifyPluginCallback,
+  FastifyPluginAsync,
+} from "fastify";
 
-import { JSONSchema7, FromSchema  } from 'json-schema-to-ts'
+import { JSONSchema7, FromSchema } from "json-schema-to-ts";
 
 export interface JsonSchemaToTsProvider extends FastifyTypeProvider {
-  output: this['input'] extends JSONSchema7 ? FromSchema<this['input']> : never
+  output: this["input"] extends JSONSchema7 ? FromSchema<this["input"]> : never;
 }
+
+/**
+ * FastifyPluginCallback with Typebox automatic type inference
+ *
+ * @example
+ * ```typescript
+ * import { FastifyPluginCallbackTypebox } fromg "@fastify/type-provider-typebox"
+ *
+ * const plugin: FastifyPluginCallbackTypebox = (fastify, options, done) => {
+ *   done()
+ * }
+ * ```
+ */
+export type FastifyPluginCallbackJStT<
+  Options extends FastifyPluginOptions = Record<never, never>,
+  Server extends RawServerBase = RawServerDefault
+> = FastifyPluginCallback<Options, Server, JsonSchemaToTsProvider>;
+
+/**
+ * FastifyPluginAsync with Typebox automatic type inference
+ *
+ * @example
+ * ```typescript
+ * import { FastifyPluginAsyncTypebox } fromg "@fastify/type-provider-typebox"
+ *
+ * const plugin: FastifyPluginAsyncTypebox = async (fastify, options) => {
+ * }
+ * ```
+ */
+export type FastifyPluginAsyncJStT<
+  Options extends FastifyPluginOptions = Record<never, never>,
+  Server extends RawServerBase = RawServerDefault
+> = FastifyPluginAsync<Options, Server, JsonSchemaToTsProvider>;

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,43 +1,43 @@
-import { FastifyPluginAsyncJStT, FastifyPluginCallbackJStT } from "../index";
+import {
+  FastifyPluginAsyncJsonSchemaToTs,
+  FastifyPluginCallbackJsonSchemaToTs,
+} from "../index";
 import { expectType } from "tsd";
 import Fastify, { FastifyPluginAsync, FastifyPluginCallback } from "fastify";
 
 import { Http2Server } from "http2";
 
-// Ensure the defaults of FastifyPluginAsyncJStT are the same as FastifyPluginAsync
+// Ensure the defaults of FastifyPluginAsyncJsonSchemaToTs are the same as FastifyPluginAsync
 export const pluginAsyncDefaults: FastifyPluginAsync = async (
   fastify,
   options
 ) => {
-  const pluginAsyncJStTDefaults: FastifyPluginAsyncJStT = async (
-    fastifyWithJStT,
-    optionsJStT
+  const pluginAsyncJStTDefaults: FastifyPluginAsyncJsonSchemaToTs = async (
+    fastifyWithJSONSchemaToTs,
+    optionsJSONSchemaToTs
   ) => {
-    expectType<typeof fastifyWithJStT["server"]>(fastify.server);
-    expectType<typeof optionsJStT>(options);
+    expectType<typeof fastifyWithJSONSchemaToTs["server"]>(fastify.server);
+    expectType<typeof optionsJSONSchemaToTs>(options);
   };
   fastify.register(pluginAsyncJStTDefaults);
 };
 
-// Ensure the defaults of FastifyPluginCallbackJStT are the same as FastifyPluginCallback
+// Ensure the defaults of FastifyPluginCallbackJsonSchemaToTs are the same as FastifyPluginCallback
 export const pluginCallbackDefaults: FastifyPluginCallback = async (
   fastify,
   options,
   done
 ) => {
-  const pluginCallbackJStTDefaults: FastifyPluginCallbackJStT = async (
-    fastifyWithJStT,
-    optionsJStT,
-    doneJStT
-  ) => {
-    expectType<typeof fastifyWithJStT["server"]>(fastify.server);
-    expectType<typeof optionsJStT>(options);
-  };
+  const pluginCallbackJStTDefaults: FastifyPluginCallbackJsonSchemaToTs =
+    async (fastifyWithJSONSchemaToTs, optionsJSONSchemaToTs, doneJStT) => {
+      expectType<typeof fastifyWithJSONSchemaToTs["server"]>(fastify.server);
+      expectType<typeof optionsJSONSchemaToTs>(options);
+    };
 
   fastify.register(pluginCallbackJStTDefaults);
 };
 
-const asyncPlugin: FastifyPluginAsyncJStT<
+const asyncPlugin: FastifyPluginAsyncJsonSchemaToTs<
   { optionA: string },
   Http2Server
 > = async (fastify, options) => {
@@ -68,7 +68,7 @@ const asyncPlugin: FastifyPluginAsyncJStT<
   );
 };
 
-const callbackPlugin: FastifyPluginCallbackJStT<
+const callbackPlugin: FastifyPluginCallbackJsonSchemaToTs<
   { optionA: string },
   Http2Server
 > = (fastify, options, done) => {

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -10,11 +10,11 @@ export const pluginAsyncDefaults: FastifyPluginAsync = async (
   options
 ) => {
   const pluginAsyncJStTDefaults: FastifyPluginAsyncJStT = async (
-    fastifyWithJstT,
-    optionsTypebox
+    fastifyWithJStT,
+    optionsJStT
   ) => {
-    expectType<typeof fastifyWithJstT["server"]>(fastify.server);
-    expectType<typeof optionsTypebox>(options);
+    expectType<typeof fastifyWithJStT["server"]>(fastify.server);
+    expectType<typeof optionsJStT>(options);
   };
   fastify.register(pluginAsyncJStTDefaults);
 };
@@ -26,12 +26,12 @@ export const pluginCallbackDefaults: FastifyPluginCallback = async (
   done
 ) => {
   const pluginCallbackJStTDefaults: FastifyPluginCallbackJStT = async (
-    fastifyWithJstT,
-    optionsTypebox,
-    doneTypebox
+    fastifyWithJStT,
+    optionsJStT,
+    doneJStT
   ) => {
-    expectType<typeof fastifyWithJstT["server"]>(fastify.server);
-    expectType<typeof optionsTypebox>(options);
+    expectType<typeof fastifyWithJStT["server"]>(fastify.server);
+    expectType<typeof optionsJStT>(options);
   };
 
   fastify.register(pluginCallbackJStTDefaults);

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -1,0 +1,106 @@
+import { FastifyPluginAsyncJStT, FastifyPluginCallbackJStT } from "../index";
+import { expectType } from "tsd";
+import Fastify, { FastifyPluginAsync, FastifyPluginCallback } from "fastify";
+
+import { Http2Server } from "http2";
+
+// Ensure the defaults of FastifyPluginAsyncJStT are the same as FastifyPluginAsync
+export const pluginAsyncDefaults: FastifyPluginAsync = async (
+  fastify,
+  options
+) => {
+  const pluginAsyncJStTDefaults: FastifyPluginAsyncJStT = async (
+    fastifyWithJstT,
+    optionsTypebox
+  ) => {
+    expectType<typeof fastifyWithJstT["server"]>(fastify.server);
+    expectType<typeof optionsTypebox>(options);
+  };
+  fastify.register(pluginAsyncJStTDefaults);
+};
+
+// Ensure the defaults of FastifyPluginCallbackJStT are the same as FastifyPluginCallback
+export const pluginCallbackDefaults: FastifyPluginCallback = async (
+  fastify,
+  options,
+  done
+) => {
+  const pluginCallbackJStTDefaults: FastifyPluginCallbackJStT = async (
+    fastifyWithJstT,
+    optionsTypebox,
+    doneTypebox
+  ) => {
+    expectType<typeof fastifyWithJstT["server"]>(fastify.server);
+    expectType<typeof optionsTypebox>(options);
+  };
+
+  fastify.register(pluginCallbackJStTDefaults);
+};
+
+const asyncPlugin: FastifyPluginAsyncJStT<
+  { optionA: string },
+  Http2Server
+> = async (fastify, options) => {
+  expectType<Http2Server>(fastify.server);
+
+  expectType<string>(options.optionA);
+
+  fastify.get(
+    "/",
+    {
+      schema: {
+        body: {
+          type: "object",
+          properties: {
+            x: { type: "string" },
+            y: { type: "number" },
+            z: { type: "boolean" },
+          },
+          required: ["x", "y", "z"],
+        } as const,
+      },
+    },
+    (req) => {
+      expectType<boolean>(req.body.z);
+      expectType<number>(req.body.y);
+      expectType<string>(req.body.x);
+    }
+  );
+};
+
+const callbackPlugin: FastifyPluginCallbackJStT<
+  { optionA: string },
+  Http2Server
+> = (fastify, options, done) => {
+  expectType<Http2Server>(fastify.server);
+
+  expectType<string>(options.optionA);
+
+  fastify.get(
+    "/",
+    {
+      schema: {
+        body: {
+          type: "object",
+          properties: {
+            x: { type: "string" },
+            y: { type: "number" },
+            z: { type: "boolean" },
+          },
+          required: ["x", "y", "z"],
+        } as const,
+      },
+    },
+    (req) => {
+      expectType<boolean>(req.body.z);
+      expectType<number>(req.body.y);
+      expectType<string>(req.body.x);
+    }
+  );
+  done();
+};
+
+const fastify = Fastify();
+
+fastify.register(asyncPlugin);
+fastify.register(callbackPlugin);

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -12,14 +12,12 @@ export const pluginAsyncDefaults: FastifyPluginAsync = async (
   fastify,
   options
 ) => {
-  const pluginAsyncJStTDefaults: FastifyPluginAsyncJsonSchemaToTs = async (
-    fastifyWithJSONSchemaToTs,
-    optionsJSONSchemaToTs
-  ) => {
-    expectType<typeof fastifyWithJSONSchemaToTs["server"]>(fastify.server);
-    expectType<typeof optionsJSONSchemaToTs>(options);
-  };
-  fastify.register(pluginAsyncJStTDefaults);
+  const pluginAsyncJSONSchemaToTsDefaults: FastifyPluginAsyncJsonSchemaToTs =
+    async (fastifyWithJSONSchemaToTs, optionsJSONSchemaToTs) => {
+      expectType<typeof fastifyWithJSONSchemaToTs["server"]>(fastify.server);
+      expectType<typeof optionsJSONSchemaToTs>(options);
+    };
+  fastify.register(pluginAsyncJSONSchemaToTsDefaults);
 };
 
 // Ensure the defaults of FastifyPluginCallbackJsonSchemaToTs are the same as FastifyPluginCallback
@@ -28,13 +26,17 @@ export const pluginCallbackDefaults: FastifyPluginCallback = async (
   options,
   done
 ) => {
-  const pluginCallbackJStTDefaults: FastifyPluginCallbackJsonSchemaToTs =
-    async (fastifyWithJSONSchemaToTs, optionsJSONSchemaToTs, doneJStT) => {
+  const pluginCallbackJSONSchemaToTsDefaults: FastifyPluginCallbackJsonSchemaToTs =
+    async (
+      fastifyWithJSONSchemaToTs,
+      optionsJSONSchemaToTs,
+      doneJSONSchemaToTs
+    ) => {
       expectType<typeof fastifyWithJSONSchemaToTs["server"]>(fastify.server);
       expectType<typeof optionsJSONSchemaToTs>(options);
     };
 
-  fastify.register(pluginCallbackJStTDefaults);
+  fastify.register(pluginCallbackJSONSchemaToTsDefaults);
 };
 
 const asyncPlugin: FastifyPluginAsyncJsonSchemaToTs<


### PR DESCRIPTION
Add plugin specifc types

- FastifyPluginAsyncJStT
- FastifyPluginCallbackJStT

I opted to use an acronym for the type name instead of for bbrevity. If the full name is prefered, I am happy to update.

- FastifyPluginAsyncJSONSchemaToTs
- FastifyPluginCallbackJSONSchemaToTs


Based on the discussion around Typebox plugin exports [here](https://github.com/fastify/fastify/issues/3636), I thought it made sense for all the type providers to export something similar

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
