### PR TITLE
fix: allow assigning provider-enabled instances to `FastifyInstance`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,7 +10,7 @@ import {
 import { JSONSchema7, FromSchema, FromSchemaOptions, FromSchemaDefaultOptions } from 'json-schema-to-ts'
 
 export interface JsonSchemaToTsProvider<Options extends FromSchemaOptions = FromSchemaDefaultOptions> extends FastifyTypeProvider {
-  output: this['input'] extends JSONSchema7 ? FromSchema<this['input'], Options> : never;
+  output: this['input'] extends JSONSchema7 ? FromSchema<this['input'], Options> : unknown;
 }
 
 /**

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,6 +4,7 @@ import Fastify, { FastifyInstance, FastifyLoggerInstance, RawReplyDefaultExpress
 
 const fastify = Fastify().withTypeProvider<JsonSchemaToTsProvider>()
 expectAssignable<FastifyInstance<RawServerDefault, RawRequestDefaultExpression, RawReplyDefaultExpression, FastifyLoggerInstance, JsonSchemaToTsProvider>>(fastify)
+expectAssignable<FastifyInstance>(fastify)
 
 fastify.get('/', {
   schema: {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added - as guide in fastify/fastify#4371
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Fix for https://github.com/fastify/fastify/issues/4342 specific to this type provider.