### PR TITLE
fix: upgrade json-schema-to-ts to v3.0.0

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,10 +7,10 @@ import {
   FastifyPluginAsync
 } from 'fastify'
 
-import { JSONSchema7, FromSchema, FromSchemaOptions, FromSchemaDefaultOptions } from 'json-schema-to-ts'
+import { JSONSchema, FromSchema, FromSchemaOptions, FromSchemaDefaultOptions } from 'json-schema-to-ts'
 
 export interface JsonSchemaToTsProvider<Options extends FromSchemaOptions = FromSchemaDefaultOptions> extends FastifyTypeProvider {
-  output: this['input'] extends JSONSchema7 ? FromSchema<this['input'], Options> : unknown;
+  output: this['input'] extends JSONSchema ? FromSchema<this['input'], Options> : unknown;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/fastify/fastify-type-provider-json-schema-to-ts#readme",
   "peerDependencies": {
     "fastify": "^4.0.0",
-    "json-schema-to-ts": "^2.0.0"
+    "json-schema-to-ts": "^3.0.0"
   },
   "tsd": {
     "directory": "types"


### PR DESCRIPTION
Found by the citgm workflow. interface JSONSchema7 got renamed to JSONSchema.
Simply upgrading to v3.0.0 solves this issue.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
