### PR TITLE
Add ValidatorSchemaOptions and SerializerSchemaOptions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,10 +10,37 @@ import {
 
 import { FromSchema, FromSchemaDefaultOptions, FromSchemaOptions, JSONSchema } from 'json-schema-to-ts'
 
-export interface JsonSchemaToTsProvider<Options extends FromSchemaOptions = FromSchemaDefaultOptions> extends FastifyTypeProvider {
-  validator: this['schema'] extends JSONSchema ? FromSchema<this['schema'], Options> : unknown;
-  serializer: this['schema'] extends JSONSchema ? FromSchema<this['schema'], Options> : unknown;
+export interface JsonSchemaToTsProviderOptions {
+  ValidatorSchemaOptions?: FromSchemaOptions;
+  SerializerSchemaOptions?: FromSchemaOptions;
 }
+
+export interface JsonSchemaToTsProvider<
+  Options extends JsonSchemaToTsProviderOptions = {}
+> extends FastifyTypeProvider {
+  validator: this['schema'] extends JSONSchema
+    ? FromSchema<
+        this['schema'],
+        Options['ValidatorSchemaOptions'] extends FromSchemaOptions
+          ? Options['ValidatorSchemaOptions']
+          : FromSchemaDefaultOptions
+      >
+    : unknown;
+  serializer: this['schema'] extends JSONSchema
+    ? FromSchema<
+        this['schema'],
+        Options['SerializerSchemaOptions'] extends FromSchemaOptions
+          ? Options['SerializerSchemaOptions']
+          : FromSchemaDefaultOptions
+      >
+    : unknown;
+}
+
+export interface FastifyPluginJsonSchemaToTsOptions extends JsonSchemaToTsProviderOptions {
+  Options?: FastifyPluginOptions;
+  Server?: RawServerBase;
+  Logger?: FastifyBaseLogger;
+};
 
 /**
  * FastifyPluginCallback with JSON Schema to Typescript automatic type inference
@@ -22,30 +49,78 @@ export interface JsonSchemaToTsProvider<Options extends FromSchemaOptions = From
  * ```typescript
  * import { FastifyPluginCallbackJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts"
  *
- * const plugin: FastifyPluginCallbackJsonSchemaToTs = (fastify, options, done) => {
+ * const plugin: FastifyPluginCallbackJsonSchemaToTs<{
+ *   ValidatorSchemaOptions: {
+ *     references: [ SchemaWrite ],
+ *   },
+ *   SerializerSchemaOptions: {
+ *     references: [ SchemaRead ],
+ *     deserialize: [{ pattern: { type: 'string'; format: 'date-time'; }; output: Date; }]
+ *   }
+ * }> = (fastify, options, done) => {
  *   done()
  * }
  * ```
  */
 export type FastifyPluginCallbackJsonSchemaToTs<
-  Options extends FastifyPluginOptions = Record<never, never>,
-  Server extends RawServerBase = RawServerDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
-> = FastifyPluginCallback<Options, Server, JsonSchemaToTsProvider, Logger>
+  Options extends FastifyPluginJsonSchemaToTsOptions = {}
+> = FastifyPluginCallback<
+  Options['Options'] extends FastifyPluginOptions
+    ? Options['Options']
+    : Record<never, never>,
+  Options['Server'] extends RawServerBase
+    ? Options['Server']
+    : RawServerDefault,
+  JsonSchemaToTsProvider<{
+    ValidatorSchemaOptions: Options['ValidatorSchemaOptions'] extends FromSchemaOptions
+      ? Options['ValidatorSchemaOptions']
+      : FromSchemaDefaultOptions,
+    SerializerSchemaOptions: Options['SerializerSchemaOptions'] extends FromSchemaOptions
+      ? Options['SerializerSchemaOptions']
+      : FromSchemaDefaultOptions
+  }>,
+  Options['Logger'] extends FastifyBaseLogger
+    ? Options['Logger']
+    : FastifyBaseLogger
+>
 
 /**
  * FastifyPluginAsync with JSON Schema to Typescript automatic type inference
  *
  * @example
  * ```typescript
- * import { FastifyPluginAsyncJsonSchemaToTs } fromg "@fastify/type-provider-json-schema-to-ts"
+ * import { FastifyPluginAsyncJsonSchemaToTs } from "@fastify/type-provider-json-schema-to-ts"
  *
- * const plugin: FastifyPluginAsyncJsonSchemaToTs = async (fastify, options) => {
+ * const plugin: FastifyPluginAsyncJsonSchemaToTs<{
+ *   ValidatorSchemaOptions: {
+ *     references: [ SchemaWrite ],
+ *   },
+ *   SerializerSchemaOptions: {
+ *     references: [ SchemaRead ],
+ *     deserialize: [{ pattern: { type: 'string'; format: 'date-time'; }; output: Date; }]
+ *   }
+ * }> = async (fastify, options) => {
  * }
  * ```
  */
 export type FastifyPluginAsyncJsonSchemaToTs<
-  Options extends FastifyPluginOptions = Record<never, never>,
-  Server extends RawServerBase = RawServerDefault,
-  Logger extends FastifyBaseLogger = FastifyBaseLogger
-> = FastifyPluginAsync<Options, Server, JsonSchemaToTsProvider, Logger>
+  Options extends FastifyPluginJsonSchemaToTsOptions = {}
+> = FastifyPluginAsync<
+  Options['Options'] extends FastifyPluginOptions
+    ? Options['Options']
+    : Record<never, never>,
+  Options['Server'] extends RawServerBase
+    ? Options['Server']
+    : RawServerDefault,
+  JsonSchemaToTsProvider<{
+    ValidatorSchemaOptions: Options['ValidatorSchemaOptions'] extends FromSchemaOptions
+      ? Options['ValidatorSchemaOptions']
+      : FromSchemaDefaultOptions,
+    SerializerSchemaOptions: Options['SerializerSchemaOptions'] extends FromSchemaOptions
+      ? Options['SerializerSchemaOptions']
+      : FromSchemaDefaultOptions
+  }>,
+  Options['Logger'] extends FastifyBaseLogger
+    ? Options['Logger']
+    : FastifyBaseLogger
+>

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -16,7 +16,7 @@ fastify.get('/', {
         z: { type: 'boolean' }
       },
       required: ['x', 'y', 'z']
-    } as const
+    }
   }
 }, (req) => {
   expectType<boolean>(req.body.z)


### PR DESCRIPTION
<details>
<summary>Original Messsage</summary>

I would like to propose that the Plugin definition of this type provider support accepting FromSchemaOptions somewhere in the generics argument, so that I can pass in schema references on routes that have external references. 

Is that something you are open to? Feedback welcome. I will add test shortly. I just wanted to open up for some feedback in terms of implementation. 

Also, do you want me to target `latest` or `next`?
</details>

This patch introduces two new options for the JsonSchemaToTsProvider: 

- `ValidatorSchemaOptions` 
- `SerializerSchemaOptions`

These are both [`FromSchemaOptions`](https://github.com/ThomasAribart/json-schema-to-ts/blob/main/src/definitions/fromSchemaOptions.ts#L12-L18)  from the [`json-schema-to-ts`](https://github.com/ThomasAribart/json-schema-to-ts#references) package.

Most importantly, they let you customize the `references` allowing for named schema references, and secondly `deserialize` which lets you customize how things are serialized and deserialized from a type perspective. See the updated examples of when this is useful.

They can be passed to the type provider and the plugin providers.

Secondly, since you don't always need to set these, and there are 2 more options, all meta type arguments have been shifted to named arguments instead of unnamed positionals.  

Where you used to write:

```ts
Fastify().withTypeProvider<
    JsonSchemaToTsProvider<{ references: [typeof sharedSchema] }>
  >();
  ```
  
 You would now write:
 
 ```ts
 Fastify().withTypeProvider<
    JsonSchemaToTsProvider<{
        ValidatorSchemaOptions: {
            references: [typeof sharedSchema]
        },
	    SerializerSchemaOptions: {
	        references: [typeof sharedSchema]
	    },
    }>
  >();
  ```
  
`FastifyPluginAsyncJsonSchemaToTs` and `FastifyPluginCallbackJsonSchemaToTs` now also accept these type parameter options, in addition to the existing but now named `Options` `Server` and `Logger` parameters.

```ts
const asyncPluginWithSchemaOptions: FastifyPluginAsyncJsonSchemaToTs<{
  Options: { optionA: string },
  Server: Http2Server,
  ValidatorSchemaOptions: {
    references: [typeof userSchema]
  },
  SerializerSchemaOptions: {
    references: [typeof serializedUserSchema],
    deserialize: [{ pattern: { type: 'string'; format: 'date-time' }; output: Date }]
  }
}> = async (fastify, options) => {
...
```

I'm happy to undo this second part, but in my experience named arguments for a complex options object like this tends to be more clear and less verbose and more explicit when you want to skip arguments you don't want to set. 

I also updated the readme and tests.

**BREAKING CHANGE**: This is a significant breaking change that requires consumers to update any code that uses type options anywhere. 

- Closes https://github.com/fastify/fastify-type-provider-json-schema-to-ts/issues/106 (deserialize option on the serializer)
- Closes https://github.com/fastify/fastify-type-provider-json-schema-to-ts/issues/65 (adds examples of additionalProperties in use)
- Closes https://github.com/fastify/fastify-type-provider-json-schema-to-ts/issues/23 (adds type tests of types applied to querystring)

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
