### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -106,5 +106,5 @@ const callbackPlugin: FastifyPluginCallbackJsonSchemaToTs<
 
 const fastify = Fastify()
 
-fastify.register(asyncPlugin)
-fastify.register(callbackPlugin)
+fastify.register(asyncPlugin, { optionA: 'a' })
+fastify.register(callbackPlugin, { optionA: 'a' })

--- a/types/plugin.test-d.ts
+++ b/types/plugin.test-d.ts
@@ -5,7 +5,7 @@ import {
   FastifyPluginCallbackJsonSchemaToTs
 } from '../index'
 
-import { Http2Server } from 'http2'
+import { Http2Server } from 'node:http2'
 
 // Ensure the defaults of FastifyPluginAsyncJsonSchemaToTs are the same as FastifyPluginAsync
 export const pluginAsyncDefaults: FastifyPluginAsync = async (


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.